### PR TITLE
feat: improve card visuals on larger screens

### DIFF
--- a/src/components/specific/ProjectCard.tsx
+++ b/src/components/specific/ProjectCard.tsx
@@ -13,10 +13,10 @@ function ProjectCard(props: { project: Project; }) {
             onClick={() => setOpen(true)}
         >
             <img
-                className="object-cover h-full z-0 absolute w-full md:h-50 xl:h-65"
+                className="object-cover h-full z-0 absolute w-full"
                 src={String(project.thumbnail)}
             />
-            <div className="z-20 flex flex-col h-full items-center justify-end py-8 px-6 w-full">
+            <div className="z-20 flex flex-col h-full items-center justify-end py-8 px-6 w-full bg-gradient-to-t from-background to-transparent">
                 <p className="font-bold text-white text-lg">{project.name}</p>
                 <p>{
                     project.tech.map((techName: string, index: Key | null | undefined) => {


### PR DESCRIPTION
## I messed up on my previous PR targeting only screen sizes under `md` breakpoint.

This addresses that, and makes card thumbnails take up the whole card background, also adding a small gradient under card text.

---

### Before:

![Screenshot 2025-05-04 at 16 15 15](https://github.com/user-attachments/assets/f34f5880-4f45-4d6e-bdb7-9bea0f789fa6)

### After:

![Screenshot 2025-05-04 at 16 15 23](https://github.com/user-attachments/assets/92f5bab9-395b-4f4e-9589-466f640bcd89)
